### PR TITLE
Remove UserToggles hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,6 @@
 	],
 	"url": "http://www.mediawiki.org/wiki/Extension:ImageFilter",
 	"Hooks": {
-		"UserToggles": "MediaWiki\\Extension\\ImageFilter\\ImageFilter::onUserToggles",
 		"PageRenderingHash": "MediaWiki\\Extension\\ImageFilter\\ImageFilter::onPageRenderingHash",
 		"ImageBeforeProduceHTML": "MediaWiki\\Extension\\ImageFilter\\ImageFilter::onImageBeforeProduceHTML",
 		"GetPreferences": "MediaWiki\\Extension\\ImageFilter\\ImageFilter::onGetPreferences",

--- a/includes/ImageFilter.php
+++ b/includes/ImageFilter.php
@@ -3,10 +3,6 @@
 namespace MediaWiki\Extension\ImageFilter;
 
 class ImageFilter {
-	public static function onUserToggles( &$extraToggles ) {
-		$extraToggles[] = 'displayfiltered';
-		return true;
-	}
 
 	public static function onPageRenderingHash( &$hash, $user, &$forOptions ) {
 		if ( $user->getOption( 'displayfiltered' ) ) {


### PR DESCRIPTION
The UserToggles hook was removed in MW 1.17 and its modern equivalent is GetPreferences, which this extension is already using.